### PR TITLE
Add basic repository templates for community interactions standarization

### DIFF
--- a/.github /ISSUE_TEMPLATE/issue_template.yml
+++ b/.github /ISSUE_TEMPLATE/issue_template.yml
@@ -1,0 +1,48 @@
+name: Bug Report
+description: Report a bug or unexpected behavior in the AntiHunter.
+title: "[Bug]: "
+labels: [bug, needs-triage]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to report a bug. Please fill out the information below to help us address the issue effectively.
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Describe the environment where the issue occurred (e.g., OS, hardware, software versions).
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Provide a detailed description of the issue.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: List the steps needed to reproduce the issue.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      description: Describe what you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Add any other context or screenshots about the issue.


### PR DESCRIPTION
ADD: Create issue_template.yml
Created an `issue_template.yml` for reporting to be standardized, more descriptive and easy to reproduce.