### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/platformio.yml
+++ b/.github/workflows/platformio.yml
@@ -1,4 +1,6 @@
 name: PlatformIO CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/lukeswitz/AntiHunter/security/code-scanning/1](https://github.com/lukeswitz/AntiHunter/security/code-scanning/1)

To fix this issue, you should explicitly set the `permissions` key at the workflow or job level, assigning the minimal permissions required. Since this workflow does not push changes, create issues, or perform any actions that require write permissions, the minimal set (`contents: read`) is sufficient. The best way is to add:

```yaml
permissions:
  contents: read
```

at the root of the workflow, just after the `name` key. This will ensure all jobs in this workflow inherit these minimal permissions unless overridden, reducing the risk associated with over-permissive tokens.

The fix will thus involve inserting a `permissions:` block beneath the `name:` (but before `on:`) in `.github/workflows/platformio.yml`. No imports or other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
