### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Code Quality
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/lukeswitz/AntiHunter/security/code-scanning/4](https://github.com/lukeswitz/AntiHunter/security/code-scanning/4)

To address this problem, you should add an explicit `permissions:` block to the workflow, scoped as tightly as possible. Since both jobs in this workflow are only running static analysis/linting and uploading artifacts, they do not need any write-level permissions, nor access to issues, PRs, etc.—they are only reading repository contents. The most restrictive and recommended starting point is:

```yaml
permissions:
  contents: read
```

This block can be added at the top (root) level, right after the `name:` field in the workflow YAML, so that it applies to all jobs. No other permissions appear to be required for these jobs. No changes to steps, or additional method/import definitions, are needed; only the addition of the explicit `permissions:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
